### PR TITLE
Initialize Next.js project structure

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Node modules
+node_modules
+
+# Next.js build
+.next
+out
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Misc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# math-course-site
-Education Fellow internal exam website.
+# Math Course Site
+
+This repository contains a Next.js project for hosting course material, assignments and interactive content for students.
+
+## Getting Started
+
+1. Install [Node.js](https://nodejs.org/) and [Git](https://git-scm.com/).
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+## Project Structure
+
+- `app/` - App Router pages and layout
+- `components/` - Reusable React components
+- `public/` - Static assets
+
+Additional packages such as Material‑UI, MathJax, Plotly and FullCalendar are listed in `package.json` but may require internet access to install.

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,0 +1,8 @@
+export default function CalendarPage() {
+  return (
+    <div>
+      <h1>Schedule</h1>
+      <p>The course calendar will appear here.</p>
+    </div>
+  );
+}

--- a/app/course/page.tsx
+++ b/app/course/page.tsx
@@ -1,0 +1,8 @@
+export default function CoursePage() {
+  return (
+    <div>
+      <h1>Course Materials</h1>
+      <p>Links to PDF documents will be listed here.</p>
+    </div>
+  );
+}

--- a/app/exercises/page.tsx
+++ b/app/exercises/page.tsx
@@ -1,0 +1,8 @@
+export default function ExercisesPage() {
+  return (
+    <div>
+      <h1>Exercises</h1>
+      <p>Math problems with hints and solutions will be added here.</p>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}

--- a/app/homework/page.tsx
+++ b/app/homework/page.tsx
@@ -1,0 +1,8 @@
+export default function HomeworkPage() {
+  return (
+    <div>
+      <h1>Homework</h1>
+      <p>Assignments and due dates will be listed here.</p>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+import NavigationTabs from '../components/NavigationTabs';
+import { CssBaseline, Container } from '@mui/material';
+import './globals.css';
+
+export const metadata = {
+  title: 'Math Course',
+  description: 'Course materials and interactive content',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <CssBaseline />
+        <NavigationTabs />
+        <Container sx={{ mt: 2 }}>{children}</Container>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <div>
+      <h1>Welcome to the Math Course</h1>
+      <p>This site contains course materials, exercises, and interactive content.</p>
+    </div>
+  );
+}

--- a/app/practical/page.tsx
+++ b/app/practical/page.tsx
@@ -1,0 +1,8 @@
+export default function PracticalPage() {
+  return (
+    <div>
+      <h1>Practical Work</h1>
+      <p>Python projects and interactive plots will be showcased here.</p>
+    </div>
+  );
+}

--- a/app/project/page.tsx
+++ b/app/project/page.tsx
@@ -1,0 +1,8 @@
+export default function ProjectPage() {
+  return (
+    <div>
+      <h1>Final Project</h1>
+      <p>Details and requirements of the final project will be provided here.</p>
+    </div>
+  );
+}

--- a/components/NavigationTabs.tsx
+++ b/components/NavigationTabs.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { AppBar, Tabs, Tab } from '@mui/material';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const tabs = [
+  { label: 'Home', href: '/' },
+  { label: 'Course', href: '/course' },
+  { label: 'Calendar', href: '/calendar' },
+  { label: 'Exercises', href: '/exercises' },
+  { label: 'Homework', href: '/homework' },
+  { label: 'Practical', href: '/practical' },
+  { label: 'Project', href: '/project' },
+];
+
+export default function NavigationTabs() {
+  const pathname = usePathname();
+  const current = tabs.findIndex(tab => tab.href === pathname);
+  return (
+    <AppBar position="static">
+      <Tabs value={current === -1 ? false : current} variant="scrollable" scrollButtons="auto">
+        {tabs.map(tab => (
+          <Tab key={tab.href} label={tab.label} component={Link} href={tab.href} />
+        ))}
+      </Tabs>
+    </AppBar>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "math-course-site",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@mui/material": "^5.15.17",
+    "@emotion/react": "^11.10.7",
+    "@emotion/styled": "^11.10.7",
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "mathjax-react": "^1.1.3",
+    "react-plotly.js": "^2.6.0",
+    "plotly.js": "^2.20.0",
+    "@fullcalendar/react": "^6.1.9",
+    "@fullcalendar/daygrid": "^6.1.9",
+    "@fullcalendar/timegrid": "^6.1.9",
+    "@fullcalendar/list": "^6.1.9"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "@types/node": "^20.9.0",
+    "@types/react": "^18.2.17",
+    "@types/react-dom": "^18.2.7",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.2.3"
+  }
+}

--- a/public/placeholder.txt
+++ b/public/placeholder.txt
@@ -1,0 +1,1 @@
+public assets

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add basic Next.js scaffold with app router
- set up Material UI navigation tabs
- update README with setup instructions

## Testing
- `npm install` *(fails: 403 Forbidden due to disabled internet)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ec779719483319ab39550ea7e9448